### PR TITLE
Add basic verl integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,19 @@ python rlvr_train.py --pool candidate_pool.pkl --model Qwen/Qwen2-7B-Instruct \
 The script saves the fine‑tuned model and value head to the `rlvr_model/`
 directory.
 
+### 8. GRPO Training (RLVR + DPO)
+
+`grpo_train.py` runs an RLVR loop and then fine‑tunes the model with Direct
+Preference Optimization. This produces a policy optimized with variance
+reduction and preference learning.
+
+```bash
+python grpo_train.py --pool candidate_pool.pkl --model Qwen/Qwen2-7B-Instruct \
+    --vllm_endpoint http://localhost:8000/generate
+```
+
+The resulting model is stored in `grpo_model/`.
+
 ## Reward Functions
 
 Available reward functions from TDC Oracle:
@@ -213,6 +226,20 @@ The results will be saved in the specified output directory:
 - JSON file with rewards for each iteration
 - Plot of rewards over iterations
 - Symlink to the best performing pool
+
+## 9. Training with verl
+
+Experimental support for the [verl](https://github.com/volcengine/verl) library
+is provided via the `verl_train.py` script. After installing `verl` you can fine
+tune a model using PPO:
+
+```bash
+pip install verl
+python verl_train.py --model Qwen/Qwen2.5-0.5B-Instruct --n 1000 --output_dir verl_output
+```
+
+This converts a candidate pool into a simple verl dataset and launches
+`verl.trainer.main_ppo` with the custom reward defined in `verl_reward.py`.
 
 ## License
 

--- a/grpo_train.py
+++ b/grpo_train.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+"""Generalized RL Preference Optimization training script.
+
+This script combines Reinforcement Learning with Variance Reduction (RLVR)
+and Direct Preference Optimization (DPO). It first runs an RLVR loop to
+collect prompt/response pairs with rewards and fine-tunes the model with a
+value head. The resulting data is then converted to preference pairs and
+used for a final DPO stage.
+"""
+
+import argparse
+import os
+import pickle
+from typing import List, Tuple
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from rlvr_train import RLDataset, collate_fn, train_rlvr
+from rl_train import train_with_dpo
+from run_iteration import (
+    calculate_rewards,
+    calculate_diversity,
+    calculate_rl_reward,
+    sample_from_pool,
+    prompt_llm,
+)
+
+
+def run_rlvr_loop(
+    pool: List[str],
+    iterations: int,
+    m: int,
+    reward_name: str,
+    endpoint: str,
+) -> Tuple[List[str], List[str], List[float], List[str]]:
+    """Run iterative generation to collect data for RLVR."""
+    prompts: List[str] = []
+    responses: List[str] = []
+    rewards: List[float] = []
+
+    candidate_pool = pool
+    for _ in range(iterations):
+        cand_rewards = calculate_rewards(candidate_pool, reward_name)
+        pos, neg = sample_from_pool(candidate_pool, cand_rewards, m)
+        new_samples = prompt_llm(pos, neg, endpoint, m)
+        new_rewards = calculate_rewards(new_samples, reward_name)
+        diversity = calculate_diversity(new_samples)
+        r = calculate_rl_reward(new_rewards, pos, diversity)
+
+        content = "\n".join([f"SMILES: {s}" for s in new_samples]) + "\n"
+        prompt = "Generate new molecules:" + "\n".join(
+            [f"SMILES: {s} ({v:.2f})" for s, v in pos]
+        ) + "\n"
+        prompts.append(prompt)
+        responses.append(content)
+        rewards.append(r)
+        candidate_pool.extend([s for s in new_samples if s not in candidate_pool])
+    return prompts, responses, rewards, candidate_pool
+
+
+def make_preference_pairs(
+    prompts: List[str],
+    responses: List[str],
+    rewards: List[float],
+) -> Tuple[List[str], List[str]]:
+    """Create preference pairs from RLVR data."""
+    triples = sorted(zip(prompts, responses, rewards), key=lambda x: x[2], reverse=True)
+    mid = len(triples) // 2
+    preferred = [p + r for p, r, _ in triples[:mid]]
+    rejected = [p + r for p, r, _ in triples[-mid:]]
+    return preferred, rejected
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="GRPO training (RLVR + DPO)")
+    parser.add_argument("--pool", required=True, help="Candidate pool pickle file")
+    parser.add_argument("--model", required=True, help="Base model path or HF id")
+    parser.add_argument("--vllm_endpoint", required=True, help="VLLM generation endpoint")
+    parser.add_argument("--output_dir", default="grpo_model", help="Directory for results")
+    parser.add_argument("--iterations", type=int, default=3, help="RL iterations")
+    parser.add_argument("--m", type=int, default=10, help="Number of pos/neg samples")
+    parser.add_argument("--reward", type=str, default="qed", help="Reward oracle name")
+    parser.add_argument("--hf_token", type=str, default=None, help="Optional HF token")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model, token=args.hf_token)
+    model = AutoModelForCausalLM.from_pretrained(args.model, token=args.hf_token)
+    value_head = torch.nn.Linear(model.config.hidden_size, 1)
+
+    with open(args.pool, "rb") as f:
+        pool = pickle.load(f)
+
+    prompts, responses, rewards, _ = run_rlvr_loop(
+        pool, args.iterations, args.m, args.reward, args.vllm_endpoint
+    )
+
+    dataset = RLDataset(prompts, responses, rewards, tokenizer)
+    train_rlvr(
+        model,
+        tokenizer,
+        dataset,
+        value_head,
+        device="cuda" if torch.cuda.is_available() else "cpu",
+    )
+
+    pref, rej = make_preference_pairs(prompts, responses, rewards)
+    train_with_dpo(
+        model,
+        tokenizer,
+        pref,
+        rej,
+        os.path.join(args.output_dir, "dpo"),
+    )
+
+    model.save_pretrained(args.output_dir)
+    tokenizer.save_pretrained(args.output_dir)
+    torch.save(value_head.state_dict(), os.path.join(args.output_dir, "value_head.pt"))
+
+
+if __name__ == "__main__":
+    main()

--- a/verl_reward.py
+++ b/verl_reward.py
@@ -1,0 +1,27 @@
+import re
+from rdkit import Chem
+from tdc import Oracle
+
+
+def extract_smiles(text: str) -> str | None:
+    """Extract a SMILES string from generated text."""
+    match = re.search(r"SMILES:\s*([^\s\n]+)", text)
+    if not match:
+        match = re.search(r"([A-Za-z0-9@\[\]\(\)=#\+-]+)", text)
+    if match:
+        smi = match.group(1).strip()
+        if Chem.MolFromSmiles(smi) is not None:
+            return smi
+    return None
+
+
+def compute_score(data_source, solution_str, ground_truth=None, extra_info=None, oracle_name="qed"):
+    """Compute reward for verl using a TDC oracle."""
+    oracle = Oracle(name=oracle_name)
+    smiles = extract_smiles(solution_str)
+    if not smiles:
+        return 0.0
+    try:
+        return float(oracle(smiles))
+    except Exception:
+        return 0.0

--- a/verl_train.py
+++ b/verl_train.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""Train a model using the verl PPO trainer on a molecular dataset."""
+
+import argparse
+import os
+import shutil
+
+from initialize_pool import initialize_candidate_pool
+from verl_utils import make_verl_dataset, run_verl_ppo
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train using verl PPO")
+    parser.add_argument("--model", required=True, help="Base model path or HF identifier")
+    parser.add_argument("--output_dir", default="verl_output", help="Directory for datasets and results")
+    parser.add_argument("--n", type=int, default=1000, help="Initial pool size")
+    parser.add_argument("--hf_token", type=str, default=None, help="HuggingFace token if needed")
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # Initialize a pool of molecules and create dataset
+    pool = initialize_candidate_pool(args.n)
+    train_file = os.path.join(args.output_dir, "train.parquet")
+    val_file = os.path.join(args.output_dir, "val.parquet")
+    make_verl_dataset(pool, train_file)
+    shutil.copy(train_file, val_file)
+
+    reward_script = os.path.join(args.output_dir, "verl_reward.py")
+    if not os.path.exists(reward_script):
+        shutil.copy("verl_reward.py", reward_script)
+
+    extra = []
+    if args.hf_token:
+        extra.append(f"actor_rollout_ref.model.token={args.hf_token}")
+        extra.append(f"critic.model.token={args.hf_token}")
+
+    run_verl_ppo(args.model, train_file, val_file, reward_script, args.output_dir, extra)
+
+
+if __name__ == "__main__":
+    main()

--- a/verl_utils.py
+++ b/verl_utils.py
@@ -1,0 +1,51 @@
+import os
+import subprocess
+from typing import List, Optional
+
+import pandas as pd
+
+
+def make_verl_dataset(smiles_list: List[str], output_file: str) -> None:
+    """Create a simple verl dataset from a list of SMILES."""
+    data = []
+    for i, smi in enumerate(smiles_list):
+        data.append(
+            {
+                "data_source": "molleo_pool",
+                "prompt": [{"role": "user", "content": f"Improve this molecule: {smi}"}],
+                "ability": "chem",
+                "reward_model": {"style": "custom"},
+                "extra_info": {"index": i},
+            }
+        )
+    pd.DataFrame(data).to_parquet(output_file)
+
+
+def run_verl_ppo(
+    model_path: str,
+    train_file: str,
+    val_file: str,
+    reward_fn: str,
+    output_dir: str,
+    extra_args: Optional[List[str]] = None,
+) -> None:
+    """Invoke the verl PPO trainer via subprocess."""
+    cmd = [
+        "python",
+        "-m",
+        "verl.trainer.main_ppo",
+        f"data.train_files={train_file}",
+        f"data.val_files={val_file}",
+        f"actor_rollout_ref.model.path={model_path}",
+        f"critic.model.path={model_path}",
+        f"reward_model.custom_reward_function.path={reward_fn}",
+        "trainer.logger=['console']",
+        "trainer.n_gpus_per_node=1",
+        "trainer.nnodes=1",
+        f"trainer.project_name=molleo_verl",
+        f"trainer.experiment_name=run",
+        f"trainer.output_dir={output_dir}",
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+    subprocess.run(cmd, check=True)


### PR DESCRIPTION
## Summary
- add example scripts for training with the `verl` library
- implement helper utilities and reward function
- document `verl` usage in README

## Testing
- `python -m py_compile verl_reward.py verl_utils.py verl_train.py single_objective/pipeline.py rl_train.py initialize_pool.py run_iteration.py`

------
https://chatgpt.com/codex/tasks/task_e_684082ab3ef483209250df8e146fc93d